### PR TITLE
add align

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -187,7 +187,7 @@ public class LinuxRISCV64CallArranger {
                    nRegs[FloatRegIdx] + floatReg <= MAX_REGISTER_ARGUMENTS;
         }
 
-        // Variadic arguments with 2xXLEN-bit alignment and size at most 2xXLEN bits are passed
+        // Variadic arguments with 2*XLEN-bit alignment and size at most 2*XLEN bits are passed
         // in an aligned register pair (i.e., the first register in the pair is even-numbered),
         // or on the stack by value if none is available.
         // After a variadic argument has been passed on the stack, all future arguments will

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -187,7 +187,7 @@ public class LinuxRISCV64CallArranger {
                    nRegs[FloatRegIdx] + floatReg <= MAX_REGISTER_ARGUMENTS;
         }
 
-        // Variadic arguments with 2*XLEN-bit alignment and size at most 2*XLEN bits are passed
+        // Variadic arguments with 2 * XLEN-bit alignment and size at most 2 * XLEN bits are passed
         // in an aligned register pair (i.e., the first register in the pair is even-numbered),
         // or on the stack by value if none is available.
         // After a variadic argument has been passed on the stack, all future arguments will

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -187,7 +187,7 @@ public class LinuxRISCV64CallArranger {
                    nRegs[FloatRegIdx] + floatReg <= MAX_REGISTER_ARGUMENTS;
         }
 
-        // Variadic arguments with 2×XLEN-bit alignment and size at most 2×XLEN bits are passed
+        // Variadic arguments with 2xXLEN-bit alignment and size at most 2xXLEN bits are passed
         // in an aligned register pair (i.e., the first register in the pair is even-numbered),
         // or on the stack by value if none is available.
         // After a variadic argument has been passed on the stack, all future arguments will

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/riscv64/linux/LinuxRISCV64CallArranger.java
@@ -190,12 +190,13 @@ public class LinuxRISCV64CallArranger {
         // Variadic arguments with 2×XLEN-bit alignment and size at most 2×XLEN bits are passed
         // in an aligned register pair (i.e., the first register in the pair is even-numbered),
         // or on the stack by value if none is available.
-        // After a variadic argument has been passed on the stack,
-        // all future arguments will also be passed on the stack
+        // After a variadic argument has been passed on the stack, all future arguments will
+        // also be passed on the stack.
         void alignStorage() {
             if (nRegs[IntegerRegIdx] + 2 <= MAX_REGISTER_ARGUMENTS) {
                 nRegs[IntegerRegIdx] = (nRegs[IntegerRegIdx] + 1) & -2;
             } else {
+                nRegs[IntegerRegIdx] = MAX_REGISTER_ARGUMENTS;
                 stackOffset = Utils.alignUp(stackOffset, 16);
             }
         }


### PR DESCRIPTION
In the base integer calling convention, variadic arguments are passed in the same manner as named arguments, with one exception. Variadic arguments with 2×XLEN-bit alignment and size at most 2×XLEN bits are passed in an aligned register pair (i.e., the first register in the pair is even-numbered), or on the stack by value if none is available. After a variadic argument has been passed on the stack, all future arguments will also be passed on the stack (i.e. the last argument register may be left unused due to the aligned register pair rule).